### PR TITLE
feat(fzf): add fzf-lua integration

### DIFF
--- a/lua/ecolog/init.lua
+++ b/lua/ecolog/init.lua
@@ -20,12 +20,14 @@
 ---@field peek boolean Mask values in peek view
 ---@field files boolean Mask values in files
 ---@field telescope boolean Mask values in telescope
+---@field fzf boolean Mask values in fzf
 
 ---@class IntegrationsConfig
 ---@field lsp boolean Enable LSP integration
 ---@field lspsaga boolean Enable LSP Saga integration
 ---@field nvim_cmp boolean Enable nvim-cmp integration
 ---@field blink_cmp boolean Enable Blink CMP integration
+---@field fzf boolean Enable fzf-lua integration
 
 ---@class LoadShellConfig
 ---@field enabled boolean Enable loading shell variables
@@ -366,6 +368,7 @@ function M.setup(opts)
         peek = false,
         files = false,
         telescope = false,
+        fzf = false,
       },
     },
     integrations = {
@@ -373,6 +376,7 @@ function M.setup(opts)
       lspsaga = false,
       nvim_cmp = true, -- Enable nvim-cmp integration by default
       blink_cmp = false, -- Disable Blink CMP integration by default
+      fzf = false,
     },
     types = true, -- Enable all types by default
     custom_types = {}, -- Custom types configuration
@@ -428,6 +432,12 @@ function M.setup(opts)
     local blink_cmp = require("ecolog.integrations.cmp.blink_cmp")
     blink_cmp.setup(opts, env_vars, providers, shelter, types, selected_env_file)
     -- No need to do anything else since Blink will create instances using Source.new()
+  end
+
+  -- Set up fzf-lua integration if enabled
+  if opts.integrations.fzf then
+    local fzf = require("ecolog.integrations.fzf")
+    fzf.setup(opts)
   end
 
   -- Lazy load providers only when needed
@@ -686,6 +696,7 @@ function M.get_config()
         peek = false,
         files = false,
         telescope = false,
+        fzf = false,
       },
     },
     integrations = {
@@ -693,6 +704,7 @@ function M.get_config()
       lspsaga = false,
       nvim_cmp = true,
       blink_cmp = false,
+      fzf = false,
     },
     types = true,
     custom_types = {},

--- a/lua/ecolog/integrations/fzf.lua
+++ b/lua/ecolog/integrations/fzf.lua
@@ -1,0 +1,118 @@
+local has_fzf, fzf = pcall(require, "fzf-lua")
+if not has_fzf then
+  error("This extension requires fzf-lua (https://github.com/ibhagwan/fzf-lua)")
+end
+
+local shelter = require("ecolog.shelter")
+
+local M = {}
+
+-- Default configuration
+local config = {
+  shelter = {
+    -- Whether to show masked values when copying to clipboard
+    mask_on_copy = false,
+  },
+  -- Default keybindings
+  mappings = {
+    -- Key to copy value to clipboard
+    copy_value = "ctrl-y",
+    -- Key to copy name to clipboard
+    copy_name = "ctrl-n",
+    -- Key to append value to buffer
+    append_value = "ctrl-a",
+    -- Key to append name to buffer (defaults to 'enter')
+    append_name = "enter",
+  },
+}
+
+function M.get_env_vars()
+  if not M._ecolog then
+    M._ecolog = require("ecolog")
+  end
+  return M._ecolog.get_env_vars()
+end
+
+local function get_masked_value(value)
+  return shelter.mask_value(value, "telescope")
+end
+
+function M.actions()
+  return {
+    -- Copy value to clipboard
+    [config.mappings.copy_value] = function(selected)
+      local entry_str = selected[1]
+      local var_name = entry_str:match("^(.-)%s*=")
+      local selection = M.get_env_vars()[var_name]
+
+      local value = config.shelter.mask_on_copy and get_masked_value(selection.value) or selection.value
+      vim.fn.setreg("+", value)
+
+      vim.notify("Copied value to clipboard", vim.log.levels.INFO)
+    end,
+
+    -- Copy name to clipboard
+    [config.mappings.copy_name] = function(selected)
+      local entry_str = selected[1]
+      local var_name = entry_str:match("^(.-)%s*=")
+
+      vim.fn.setreg("+", var_name)
+      vim.notify("Copied variable name to clipboard", vim.log.levels.INFO)
+    end,
+
+    -- Append environment name to buffer
+    [config.mappings.append_name] = function(selected)
+      local entry_str = selected[1]
+      local var_name = entry_str:match("^(.-)%s*=")
+      local selection = M.get_env_vars()[var_name]
+
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      local line = vim.api.nvim_get_current_line()
+      local new_line = line:sub(1, cursor[2]) .. selection.name .. line:sub(cursor[2] + 1)
+
+      vim.api.nvim_set_current_line(new_line)
+      vim.api.nvim_win_set_cursor(0, { cursor[1], cursor[2] + #selection.name })
+      vim.notify("Appended environment name", vim.log.levels.INFO)
+    end,
+
+    -- Append environment value to buffer
+    [config.mappings.append_value] = function(selected)
+      local entry_str = selected[1]
+      local var_name = entry_str:match("^(.-)%s*=")
+      local selection = M.get_env_vars()[var_name]
+      local value = config.shelter.mask_on_copy and get_masked_value(selection.value) or selection.value
+
+      local cursor = vim.api.nvim_win_get_cursor(0)
+      local line = vim.api.nvim_get_current_line()
+      local new_line = line:sub(1, cursor[2]) .. value .. line:sub(cursor[2] + 1)
+      vim.api.nvim_set_current_line(new_line)
+      vim.api.nvim_win_set_cursor(0, { cursor[1], cursor[2] + #value })
+
+      vim.notify("Appended environment value", vim.log.levels.INFO)
+    end,
+  }
+end
+
+function M.env_picker(fzf_opts)
+  local results = {}
+  for var_name, var_info in pairs(M.get_env_vars()) do
+    local display_value = get_masked_value(var_info.value)
+    table.insert(results, string.format("%-30s = %s", var_name, display_value))
+  end
+
+  local default_opts = {}
+
+  default_opts.previewer = false
+  default_opts.actions = M.actions()
+
+  fzf_opts = vim.tbl_deep_extend("force", default_opts, fzf_opts or {})
+
+  fzf.fzf_exec(results, fzf_opts)
+end
+
+function M.setup(opts)
+  config = vim.tbl_deep_extend("force", config, opts or {})
+  M.fzf = M.env_picker
+end
+
+return M

--- a/lua/ecolog/shelter.lua
+++ b/lua/ecolog/shelter.lua
@@ -22,7 +22,7 @@ local PATTERNS = {
 local namespace = api.nvim_create_namespace("ecolog_shelter")
 
 -- Features list for iteration
-local FEATURES = { "cmp", "peek", "files", "telescope" }
+local FEATURES = { "cmp", "peek", "files", "telescope", "fzf" }
 
 -- Use local cache for frequently accessed values
 local state = {
@@ -105,11 +105,11 @@ local function shelter_buffer()
 
     local key = string_sub(line, 1, eq_pos - 1)
     local value = string_sub(line, eq_pos + 1)
-    
+
     -- Clean up key and value
     key = string_match(key, "^%s*(.-)%s*$")
     value = string_match(value, "^%s*(.-)%s*$")
-    
+
     if not (key and value) then
       goto continue
     end
@@ -311,7 +311,7 @@ function M.set_state(command, feature)
 
   if feature then
     if not tbl_contains(FEATURES, feature) then
-      notify("Invalid feature. Use 'cmp', 'peek', 'files', or 'telescope'", vim.log.levels.ERROR)
+      notify("Invalid feature. Use 'cmp', 'peek', 'files', 'telescope', or 'fzf'", vim.log.levels.ERROR)
       return
     end
 


### PR DESCRIPTION
Add [fzf-lua](https://github.com/ibhagwan/fzf-lua.git) integration.

I'm new to Lua and plugin development so there are a few problems.

- I don't know how to take in `fzf-lua` user's opts for the picker.
- How to make it invokable through `require("ecolog").fzf()` instead of `require("ecolog.integrations.fzf").fzf()`.

The logic of `actions` are directly copied from `telescope` extension.