### PR TITLE
fix: wrong opt value in setup function

### DIFF
--- a/lua/ecolog/init.lua
+++ b/lua/ecolog/init.lua
@@ -414,7 +414,7 @@ function M.setup(opts)
 
   if opts.integrations.fzf then
     local fzf = require("ecolog.integrations.fzf")
-    fzf.setup(opts.integrations.fzf)
+    fzf.setup(type(opts.integrations.fzf) == "table" and opts.integrations.fzf or {})
   end
 
   local initial_env_files = find_env_files({
@@ -600,7 +600,7 @@ function M.setup(opts)
           return
         end
         if not fzf._initialized then
-          fzf.setup(opts)
+          fzf.setup(type(opts.integrations.fzf) == "table" and opts.integrations.fzf or {})
           fzf._initialized = true
         end
         fzf.env_picker()

--- a/lua/ecolog/init.lua
+++ b/lua/ecolog/init.lua
@@ -404,17 +404,17 @@ function M.setup(opts)
 
   if opts.integrations.nvim_cmp then
     local nvim_cmp = require("ecolog.integrations.cmp.nvim_cmp")
-    nvim_cmp.setup(opts, state.env_vars, providers, shelter, types, state.selected_env_file)
+    nvim_cmp.setup(opts.integrations.nvim_cmp, state.env_vars, providers, shelter, types, state.selected_env_file)
   end
 
   if opts.integrations.blink_cmp then
     local blink_cmp = require("ecolog.integrations.cmp.blink_cmp")
-    blink_cmp.setup(opts, state.env_vars, providers, shelter, types, state.selected_env_file)
+    blink_cmp.setup(opts.integrations.blink_cmp, state.env_vars, providers, shelter, types, state.selected_env_file)
   end
 
   if opts.integrations.fzf then
     local fzf = require("ecolog.integrations.fzf")
-    fzf.setup(opts)
+    fzf.setup(opts.integrations.fzf)
   end
 
   local initial_env_files = find_env_files({


### PR DESCRIPTION
I noticed that the setup function might have some issues with the opts. The opts for cmp and blink.cmp are not being used, but the opt for fzff is. This pr fixes the problem where the opt value for fzf integration wasn’t working.