### PR TITLE
feat(snacks): use column display highlights and customizable layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,6 +806,10 @@ require('ecolog').setup({
         append_value = "<C-a>", -- Append value at cursor position
         append_name = "<CR>",   -- Append name at cursor position
       },
+      layout = {  -- Any Snacks layout configuration
+        preset = "dropdown",
+        preview = false,
+      },
     }
   }
 })


### PR DESCRIPTION
This PR brings small adjustments:
- columnar display with dynamic width (adjust to the biggest variable name)
- highlights
- simplify item payloads
- `layout` can be configured

### Before

![image](https://github.com/user-attachments/assets/b47cc815-ae80-49b9-a4b9-7fd18094df0b)

### After

![image](https://github.com/user-attachments/assets/798850d6-f44c-4f32-a945-f562984bae44)
